### PR TITLE
Replacing manual argv parsing with commander

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/index.js
+++ b/index.js
@@ -55,11 +55,10 @@ else
   throw new Error("Expecting a port argument to -p, --port")
 
 // Non-option arguments, take the first one as file or display help
-if(!args.args.length)
+if(!args.args.length && !args.expr)
   args.help();
 else
-  args.file = args.args[0];
-  console.log(args.updateFirmware)
+  args.file = args.args[0] || false;
 
 // Extra argument stuff
 args.espruinoPrefix = args.quiet?"":"--]";

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "url": "https://github.com/espruino/espruino-tools"
   },
   "dependencies": {
-    "serialport": "~1.2.5",
+    "acorn": "~0.6.0",
+    "commander": "~2.8.0",
     "jquery": "~2.1.1",
-    "jsdom":"~1.0.0",
-    "xmlhttprequest":"~1.7.0",
-    "acorn":"~0.6.0"
+    "jsdom": "~1.0.0",
+    "serialport": "~1.2.5",
+    "xmlhttprequest": "~1.7.0"
   },
   "keywords": [
     "espruino"


### PR DESCRIPTION
Using commander for argv parsing makes this package far more extensible, there are very few edge cases (i.e. random spaces and linebreaks) that have to be accounted for in parsing. See [commander](https://github.com/tj/commander.js) for any other information
